### PR TITLE
License name unification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,16 @@
-DAEDAL Open Source License
+Eta Scale Open Source License
 
-By accessing or using DAEDAL in any form you expressly undertake to be bound
+By accessing or using the software that is licensed under the terms of this
+document ("Eta Scale Software") in any form you expressly undertake to be bound
 by these license terms. If you use the code on behalf of a business, you agree
 to these license terms both in person and on behalf of that business and you
 represent that you have the authority to do so.
 
 1) Alternative License
 
-	DAEDAL is distributed under a dual-license scheme, an open source and
-	a commercial license. This document is the open source license.
+	Eta Scale Software is distributed under a dual-license scheme,
+	an open source and a commercial license.
+	This document is the open source license.
 
 	If you are interested in the commercial license, please contact
 	Eta Scale AB by email: contact@etascale.com
@@ -35,16 +37,16 @@ represent that you have the authority to do so.
 	are met:
 
 	Redistributions of source code must retain all conditions of the
-	DAEDAL Open Source License. Redistributions in binary form must
-	reproduce the terms of the DAEDAL Open Source License in the
+	Eta Scale Open Source License. Redistributions in binary form must
+	reproduce the terms of the Eta Scale Open Source License in the
 	documentation and/or other materials provided with the distribution.
 	Neither redistributions in source code or in binary form may impose
 	any further restrictions on the exercise of the rights granted or
-	affirmed under the DAEDAL Open Source License.
+	affirmed under the Eta Scale Open Source License.
 
 	Redistributions in any form must be accompanied by information on how to
-	obtain complete source code for the DAEDAL software and any
-	accompanying software that uses the DAEDAL software. The source code
+	obtain complete source code for the Eta Scale Software and any
+	accompanying software that uses the Eta Scale Software. The source code
 	must either be included in the distribution or be available for no
 	more than the cost of distribution. For an executable file, complete
 	source code means the source code for all modules it contains. It does
@@ -52,14 +54,14 @@ represent that you have the authority to do so.
 	the major components of the operating system on which the executable
 	file runs.
 
-	Neither the name DAEDAL nor the names of any of its contributors may be
-	used to endorse or promote products derived from this software
-	without specific prior written permission.
+	Neither the name Eta Scale, nor the names of any of its projects or
+	contributors may be used to endorse or promote products derived from
+	Eta Scale Software without specific prior written permission.
 
 4) Copyleft for Software Users
 
-	Notwithstanding any other provision of the DAEDAL Open Source
-	License, if you modify the DAEDAL software, your modified version
+	Notwithstanding any other provision of the Eta Scale Open Source
+	License, if you modify the Eta Scale Software, your modified version
 	must prominently offer all users interacting with it an opportunity to
 	receive the corresponding source code of your version.
 	If the interaction happens remotely through a computer network (if
@@ -70,8 +72,8 @@ represent that you have the authority to do so.
 
 5) License for Contributions
 
-	For any of your modifications or other derivations of the DAEDAL
-	source code ("your Contributions"), you grant Eta Scale AB a
+	For any of your modifications or other derivations of the Eta Scale
+	Software source code ("your Contributions"), you grant Eta Scale AB a
 	non-exclusive, irrevocable, worldwide, no-charge, transferable license
 	to use,	execute, create derivative works of, and distribute
 	(internally and	externally) or otherwise use commercially or
@@ -80,15 +82,15 @@ represent that you have the authority to do so.
 	Except for the rights granted to Eta Scale AB in this paragraph, you
 	reserve all rights, title and interest in and to your Contributions.
 
-6) Non-Severability of the DAEDAL Open Source License
+6) Non-Severability of the Eta Scale Open Source License
 
-	If any part of the DAEDAL Open Source License is invalid, or becomes
+	If any part of the Eta Scale Open Source License is invalid, or becomes
 	invalid, then the entire license shall become invalid, and any rights
-	you derived from the DAEDAL Open Source License shall be null and void.
-	This shall not affect the License for your Contributions that you have
-	given according to Section 5 of the DAEDAL Open Source License, which
-	shall remain valid even if the DAEDAL Open Source License itself is
-	invalid, or becomes invalid.
+	you derived from the Eta Scale Open Source License shall be null and
+	void. This shall not affect the License for your Contributions that you
+	have given according to Section 5 of the Eta Scale Open Source License,
+	which shall remain valid even if the Eta Scale Open Source License
+	itself is invalid, or becomes invalid.
 
 7) Choice of Law
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 #------------------------------------------------------------------------------
 # CMakeLists.txt

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 #------------------------------------------------------------------------------
 # Makefile

--- a/compiler/projects/CMakeLists.txt
+++ b/compiler/projects/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 set(PROJECTS_MAIN_SRC_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(PROJECTS_MAIN_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/compiler/projects/include/DAE/Utils/SkelUtils/headers.h
+++ b/compiler/projects/include/DAE/Utils/SkelUtils/headers.h
@@ -10,7 +10,7 @@
 ///
 /// \brief General includes for DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/ADT/SmallVector.h"

--- a/compiler/projects/include/Util/Analysis/LoopCarriedDependencyAnalysis.h
+++ b/compiler/projects/include/Util/Analysis/LoopCarriedDependencyAnalysis.h
@@ -10,7 +10,7 @@
 ///
 /// \brief LCD Analysis Interface
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //
 // This file defines the generic LoopCarriedDependencyAnalysis interface, which

--- a/compiler/projects/include/Util/Annotation/MetadataInfo.h
+++ b/compiler/projects/include/Util/Annotation/MetadataInfo.h
@@ -10,7 +10,7 @@
 ///
 /// \brief MetadataInfo Interface
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //
 // This file defines utilities to read and attach metadata to instructions.

--- a/compiler/projects/src/CMakeLists.txt
+++ b/compiler/projects/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(DAE)

--- a/compiler/projects/src/DAE/CMakeLists.txt
+++ b/compiler/projects/src/DAE/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(Transform)
 add_subdirectory(Utils)

--- a/compiler/projects/src/DAE/Transform/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Transform/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(FKernelPrefetch)
 

--- a/compiler/projects/src/DAE/Transform/FKernelPrefetch/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Transform/FKernelPrefetch/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(FKernelPrefetch SHARED
   FKernelPrefetch.cpp

--- a/compiler/projects/src/DAE/Transform/FKernelPrefetch/FKernelPrefetch.cpp
+++ b/compiler/projects/src/DAE/Transform/FKernelPrefetch/FKernelPrefetch.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief DAE with Multiversioning
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //
 // This file implements a pass identify every function with "_kernel_"

--- a/compiler/projects/src/DAE/Utils/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(LoopChunk)
 add_subdirectory(LoopExtract)

--- a/compiler/projects/src/DAE/Utils/LoopChunk/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/LoopChunk/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(LoopChunk SHARED LoopChunk.cpp
     ${PROJECTS_MAIN_INCLUDE_DIR}/Util/Analysis 

--- a/compiler/projects/src/DAE/Utils/LoopChunk/LoopChunk.cpp
+++ b/compiler/projects/src/DAE/Utils/LoopChunk/LoopChunk.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Transforms a loop into a doubly nested loop (strip mining)
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/Analysis/AliasAnalysis.h"

--- a/compiler/projects/src/DAE/Utils/LoopExtract/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/LoopExtract/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(LoopExtract MODULE LoopExtract.cpp)
 

--- a/compiler/projects/src/DAE/Utils/LoopExtract/LoopExtract.cpp
+++ b/compiler/projects/src/DAE/Utils/LoopExtract/LoopExtract.cpp
@@ -11,7 +11,7 @@
 ///
 /// \brief Extracts DAE-targeted loop
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/Analysis/LoopPass.h"

--- a/compiler/projects/src/DAE/Utils/RemoveRedundantPref/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/RemoveRedundantPref/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(RemoveRedundantPref MODULE RemoveRedundantPref.cpp)
 

--- a/compiler/projects/src/DAE/Utils/RemoveRedundantPref/RemoveRedundantPref.cpp
+++ b/compiler/projects/src/DAE/Utils/RemoveRedundantPref/RemoveRedundantPref.cpp
@@ -11,7 +11,7 @@
 ///
 /// \brief Pass to remove redundant prefetches
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/Analysis/AliasAnalysis.h"

--- a/compiler/projects/src/DAE/Utils/SkelUtils/CFGhacking.cpp
+++ b/compiler/projects/src/DAE/Utils/SkelUtils/CFGhacking.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Utility for CFG transformations of DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 

--- a/compiler/projects/src/DAE/Utils/SkelUtils/CallingDAE.cpp
+++ b/compiler/projects/src/DAE/Utils/SkelUtils/CallingDAE.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Utility for calling and timing DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/Analysis/LoopPass.h"

--- a/compiler/projects/src/DAE/Utils/SkelUtils/HandleVirtualIterators.cpp
+++ b/compiler/projects/src/DAE/Utils/SkelUtils/HandleVirtualIterators.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Utility to add virtual iterator
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //
 // This file provides the functions for inserting a virtual

--- a/compiler/projects/src/DAE/Utils/SkelUtils/LoopUtils.cpp
+++ b/compiler/projects/src/DAE/Utils/SkelUtils/LoopUtils.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Utility for LoopChunking
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "DAE/Utils/SkelUtils/headers.h"

--- a/compiler/projects/src/DAE/Utils/SkelUtils/Utils.cpp
+++ b/compiler/projects/src/DAE/Utils/SkelUtils/Utils.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Determines which functions to target for DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 using namespace llvm;

--- a/compiler/projects/src/DAE/Utils/StoreBack/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/StoreBack/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(StoreBack SHARED
   ${PROJECTS_MAIN_SRC_DIR}/Util/Annotation/MetadataInfo.cpp

--- a/compiler/projects/src/DAE/Utils/StoreBack/StoreBack.cpp
+++ b/compiler/projects/src/DAE/Utils/StoreBack/StoreBack.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Create backups for problematic stores
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 

--- a/compiler/projects/src/DAE/Utils/TimeOrig/CMakeLists.txt
+++ b/compiler/projects/src/DAE/Utils/TimeOrig/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(TimeOrig MODULE TimeOrig.cpp)
 

--- a/compiler/projects/src/DAE/Utils/TimeOrig/TimeOrig.cpp
+++ b/compiler/projects/src/DAE/Utils/TimeOrig/TimeOrig.cpp
@@ -10,7 +10,7 @@
 ///
 /// \brief Inserts timing information for CAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //===----------------------------------------------------------------------===//
 #include "llvm/IR/Constants.h"

--- a/compiler/projects/src/Util/Annotation/MetadataInfo.cpp
+++ b/compiler/projects/src/Util/Annotation/MetadataInfo.cpp
@@ -11,7 +11,7 @@
 ///
 /// \brief
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See
 /// the LICENSE file for details.
 //
 // Description of pass ...

--- a/compiler/tools/CMakeLists.txt
+++ b/compiler/tools/CMakeLists.txt
@@ -1,3 +1,3 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(DVFS)

--- a/compiler/tools/DVFS/CMakeLists.txt
+++ b/compiler/tools/DVFS/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 include_directories(include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/compiler/tools/DVFS/include/profiler.h
+++ b/compiler/tools/DVFS/include/profiler.h
@@ -2,7 +2,7 @@
 ///
 /// \brief Interfacing DVFS support for DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 #include <cpufreq.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/compiler/tools/DVFS/src/CMakeLists.txt
+++ b/compiler/tools/DVFS/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(DAE_prof_ST STATIC profiler.cpp)
 add_library(DAE_prof_OMP STATIC profiler.cpp)

--- a/compiler/tools/DVFS/src/profiler.cpp
+++ b/compiler/tools/DVFS/src/profiler.cpp
@@ -2,7 +2,7 @@
 ///
 /// \brief Interfacing DVFS support for DAE
 ///
-/// \copyright Eta Scale. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+/// \copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 #include <cpufreq.h>
 
 #include "profiler.h"

--- a/daedal-scripts/dae-buildscripts/build-all.sh
+++ b/daedal-scripts/dae-buildscripts/build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 echoerr() { echo "$@" >&2; }
 

--- a/daedal-scripts/dae-buildscripts/build.sh
+++ b/daedal-scripts/dae-buildscripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 echoerr() { echo "$@" >&2; }
 

--- a/daedal-scripts/dae-buildscripts/compile-bench.sh
+++ b/daedal-scripts/dae-buildscripts/compile-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 ## Warning ##
 # This script does not contain any parameter failsafes and should therfore

--- a/daedal-scripts/dae-buildscripts/compileSPEC.sh
+++ b/daedal-scripts/dae-buildscripts/compileSPEC.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 ## Warning ##
 # This script does not contain any parameter failsafes and should therfore

--- a/daedal-scripts/dae-buildscripts/set-env.sh
+++ b/daedal-scripts/dae-buildscripts/set-env.sh
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the DAEDAL Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 # This script sets the environment needed by the other scripts.
 # The lines in this script needs to be run by a parent


### PR DESCRIPTION
This changes the License name to Eta Scale Open Source License,
which allows the same license text to be used for all projects
of Eta Scale AB.
